### PR TITLE
Compile fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+*.o
+# compiled files
+bench/bulk_extract/bulk_extract
+bench/bulk_insert/bulk_insert
+bench/bulk_update/bulk_update
+bench/hotspot_read/hotspot_read
+bench/mkpairs/mkpairs
+bench/random_mixed/random_mixed
+bench/random_read/random_read
+kvlds/kvlds
+lbs-s3/lbs-s3
+lbs/lbs
+mux/mux
+perftests/http/test_http
+perftests/kvldsclean/test_kvldsclean
+perftests/kvldsperf/test_kvldsperf
+perftests/s3/test_s3
+perftests/s3_put/s3_put
+s3/s3
+tests/crc32/test_crc32
+tests/heap/test_heap
+tests/kvlds-s3/test_kvlds
+tests/kvlds/test_kvlds
+tests/lbs/test_lbs
+tests/mux/test_mux
+tests/s3/test_s3

--- a/bench/bulk_extract/Makefile
+++ b/bench/bulk_extract/Makefile
@@ -72,3 +72,5 @@ IDIRS	+=	-I ../../lib/proto_kvlds
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/bench/bulk_insert/Makefile
+++ b/bench/bulk_insert/Makefile
@@ -72,3 +72,5 @@ IDIRS	+=	-I ../../lib/proto_kvlds
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/bench/bulk_update/Makefile
+++ b/bench/bulk_update/Makefile
@@ -72,3 +72,5 @@ IDIRS	+=	-I ../../lib/proto_kvlds
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/bench/hotspot_read/Makefile
+++ b/bench/hotspot_read/Makefile
@@ -76,3 +76,5 @@ IDIRS	+=	-I ../../lib/proto_kvlds
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/bench/hotspot_read/Makefile
+++ b/bench/hotspot_read/Makefile
@@ -21,6 +21,7 @@ IDIRS	+=	-I ../../lib/datastruct
 
 # Utility functions
 .PATH.c	:	../../libcperciva/util
+SRCS	+=	insecure_memzero.c
 SRCS	+=	monoclock.c
 SRCS	+=	sock.c
 SRCS	+=	warnp.c

--- a/bench/mkpairs/Makefile
+++ b/bench/mkpairs/Makefile
@@ -3,6 +3,7 @@ SRCS=	main.c
 
 # Utility functions
 .PATH.c	:	../../libcperciva/util
+SRCS	+=	insecure_memzero.c
 SRCS	+=	warnp.c
 IDIRS	+=	-I ../../libcperciva/util
 .PATH.c	:	../lib/

--- a/bench/random_mixed/Makefile
+++ b/bench/random_mixed/Makefile
@@ -76,3 +76,5 @@ IDIRS	+=	-I ../../lib/proto_kvlds
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/bench/random_mixed/Makefile
+++ b/bench/random_mixed/Makefile
@@ -21,6 +21,7 @@ IDIRS	+=	-I ../../lib/datastruct
 
 # Utility functions
 .PATH.c	:	../../libcperciva/util
+SRCS	+=	insecure_memzero.c
 SRCS	+=	monoclock.c
 SRCS	+=	sock.c
 SRCS	+=	warnp.c

--- a/bench/random_read/Makefile
+++ b/bench/random_read/Makefile
@@ -76,3 +76,5 @@ IDIRS	+=	-I ../../lib/proto_kvlds
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/bench/random_read/Makefile
+++ b/bench/random_read/Makefile
@@ -21,6 +21,7 @@ IDIRS	+=	-I ../../lib/datastruct
 
 # Utility functions
 .PATH.c	:	../../libcperciva/util
+SRCS	+=	insecure_memzero.c
 SRCS	+=	monoclock.c
 SRCS	+=	sock.c
 SRCS	+=	warnp.c

--- a/kvlds/Makefile
+++ b/kvlds/Makefile
@@ -109,3 +109,5 @@ IDIRS	+=	-I ../lib/proto_kvlds
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/lbs-s3/Makefile
+++ b/lbs-s3/Makefile
@@ -87,3 +87,5 @@ IDIRS	+=	-I ../lib/proto_lbs
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/lbs/Makefile
+++ b/lbs/Makefile
@@ -85,3 +85,5 @@ IDIRS	+=	-I ../lib/proto_lbs
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/lib/http/http.c
+++ b/lib/http/http.c
@@ -268,7 +268,7 @@ http_request(struct sock_addr * const * addrs, struct http_request * request,
 	H->req_headlen += 2;			/* Blank line. */
 
 	/* Allocate space for header plus NUL byte (so we can use stpcpy). */
-	if ((s = H->req_head = malloc(H->req_headlen + 1)) == NULL)
+	if ((s = (char *)(H->req_head = malloc(H->req_headlen + 1))) == NULL)
 		goto err1;
 
 	/* Construct request line. */
@@ -431,7 +431,7 @@ gotheaders(struct http_cookie * H, uint8_t * buf, size_t buflen)
 	bufpos = 0;
 
 	/* Find the status-line and check for premature NULs. */
-	s = sgetline(H->res_head, H->res_headlen, &bufpos, &linelen);
+	s = (char *)(sgetline(H->res_head, H->res_headlen, &bufpos, &linelen));
 	if (strlen(s) < linelen) {
 		warn0("Status line contains NUL byte");
 		return (fail(H));
@@ -450,7 +450,8 @@ gotheaders(struct http_cookie * H, uint8_t * buf, size_t buflen)
 	/* Parse headers. */
 	for (i = 0; i < H->res.nheaders; i++) {
 		/* Grab a line. */
-		s = sgetline(H->res_head, H->res_headlen, &bufpos, &linelen);
+		s = (char*)
+		    (sgetline(H->res_head, H->res_headlen, &bufpos, &linelen));
 		if (strlen(s) < linelen) {
 			warn0("Header contains NUL byte");
 			return (fail(H));
@@ -615,7 +616,7 @@ callback_chunkedheader(void * cookie, int status)
 	/* If we found one, handle the line. */
 	if (eolpos != buflen) {
 		/* Parse the chunk length. */
-		clen = strtoull(buf, NULL, 16);
+		clen = strtoull((const char *)buf, NULL, 16);
 
 		/* Consume the line and EOL. */
 		netbuf_read_consume(H->R, eolpos + 2);

--- a/mux/Makefile
+++ b/mux/Makefile
@@ -71,3 +71,5 @@ IDIRS	+=	-I ../lib/wire
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/perftests/http/Makefile
+++ b/perftests/http/Makefile
@@ -10,6 +10,7 @@ IDIRS	+=	-I ../../libcperciva/datastruct
 
 # Utility functions
 .PATH.c	:	../../libcperciva/util
+SRCS	+=	asprintf.c
 SRCS	+=	monoclock.c
 SRCS	+=	sock.c
 SRCS	+=	warnp.c

--- a/perftests/http/Makefile
+++ b/perftests/http/Makefile
@@ -50,3 +50,5 @@ test:	test_http
 	@./test_http www.tarsnap.com /kivaloo.html
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/perftests/http/main.c
+++ b/perftests/http/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "asprintf.h"
 #include "events.h"
 #include "http.h"
 #include "sock.h"

--- a/perftests/kvldsclean/Makefile
+++ b/perftests/kvldsclean/Makefile
@@ -84,3 +84,5 @@ test:	all
 	@rm -r stor
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/perftests/kvldsclean/main.c
+++ b/perftests/kvldsclean/main.c
@@ -51,7 +51,7 @@ batch_set(struct wire_requestqueue * Q, size_t start, size_t N)
 	for (x = start; x < start + N; x++) {
 		/* Set "$x" = "$x". */
 		sprintf(buf, "%08zu", x);
-		if ((key = kvldskey_create(buf, 8)) == NULL)
+		if ((key = kvldskey_create((uint8_t *)buf, 8)) == NULL)
 			goto err0;
 		if (proto_kvlds_request_set(Q, key, key, callback_done, &C)) {
 			warnp("Failed to send SET request");
@@ -93,7 +93,7 @@ batch_delete(struct wire_requestqueue * Q, size_t start, size_t N)
 	for (x = start; x < start + N; x++) {
 		/* Delete "$x". */
 		sprintf(buf, "%08zu", x);
-		if ((key = kvldskey_create(buf, 8)) == NULL)
+		if ((key = kvldskey_create((uint8_t *)buf, 8)) == NULL)
 			goto err0;
 		if (proto_kvlds_request_delete(Q, key, callback_done, &C)) {
 			warnp("Failed to send DELETE request");

--- a/perftests/kvldsperf/Makefile
+++ b/perftests/kvldsperf/Makefile
@@ -179,3 +179,5 @@ CLEANFILES+=	kvlds.gmon kvlds-ADD.gprof kvlds-MODIFY.gprof
 CLEANFILES+=	mux.gmon mux.gprof
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/perftests/s3/Makefile
+++ b/perftests/s3/Makefile
@@ -61,3 +61,5 @@ test:	test_s3
 	./test_s3 `head -1 ~/.aws/aws_test_key` `tail -1 ~/.aws/aws_test_key`
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/perftests/s3/Makefile
+++ b/perftests/s3/Makefile
@@ -18,6 +18,7 @@ IDIRS	+=	-I ../../libcperciva/datastruct
 .PATH.c	:	../../libcperciva/util
 SRCS	+=	asprintf.c
 SRCS	+=	b64encode.c
+SRCS	+=	insecure_memzero.c
 SRCS	+=	monoclock.c
 SRCS	+=	sock.c
 SRCS	+=	warnp.c

--- a/perftests/s3/main.c
+++ b/perftests/s3/main.c
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
 	R.nheaders = 0;
 	R.headers = NULL;
 	R.bodylen = strlen("ha-ha\n");
-	R.body = "ha-ha\n";
+	R.body = (const uint8_t *)"ha-ha\n";
 
 	/* Send PUT request. */
 	done = 0;

--- a/perftests/s3_put/Makefile
+++ b/perftests/s3_put/Makefile
@@ -70,3 +70,5 @@ test:
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -99,3 +99,5 @@ IDIRS	+=	-I ../lib/proto_s3
 #CFLAGS	+=	-pg
 
 .include <bsd.prog.mk>
+
+CFLAGS +=	-Wno-unused-function

--- a/tests/crc32/main.c
+++ b/tests/crc32/main.c
@@ -34,7 +34,8 @@ main(int argc, char * argv[])
 	for (i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
 		printf("Computing CRC32C of \"%s\"...", tests[i].s);
 		CRC32C_Init(&ctx);
-		CRC32C_Update(&ctx, tests[i].s, strlen(tests[i].s));
+		CRC32C_Update(&ctx, (const uint8_t *)tests[i].s,
+		    strlen(tests[i].s));
 		CRC32C_Final(cbuf, &ctx);
 		if (memcmp(cbuf, tests[i].cbuf, 4)) {
 			printf(" FAILED!\n");

--- a/tests/heap/Makefile
+++ b/tests/heap/Makefile
@@ -18,3 +18,4 @@ test:	test_heap
 
 .include <bsd.prog.mk>
 
+CFLAGS	+=	-Wno-unused-function

--- a/tests/heap/Makefile
+++ b/tests/heap/Makefile
@@ -9,7 +9,7 @@ IDIRS	+=	-I ../../libcperciva/datastruct
 test:	test_heap
 	@echo -n "Heapsorting main.c..."
 	@./test_heap < main.c > main.c.sorted
-	@if sort < main.c | cmp - main.c.sorted; then	\
+	@if LC_ALL=C sort < main.c | cmp - main.c.sorted; then	\
 		echo " PASSED!";			\
 		rm main.c.sorted;			\
 	else						\

--- a/tests/heap/main.c
+++ b/tests/heap/main.c
@@ -4,6 +4,8 @@
 
 #include "ptrheap.h"
 
+#define MAX_LINE_LENGTH 128
+
 static int
 compar(void * cookie, const void * x, const void * y)
 {
@@ -20,7 +22,7 @@ main(int argc, char * argv[])
 {
 	struct ptrheap * H;
 	char * s, * dups;
-	size_t l;
+	char input[MAX_LINE_LENGTH];
 
 	(void)argc; /* UNUSED */
 	(void)argv; /* UNUSED */
@@ -30,12 +32,12 @@ main(int argc, char * argv[])
 		exit(1);
 
 	/* Suck in the input. */
-	while ((s = fgetln(stdin, &l)) != NULL) {
-		/* NUL-terminate. */
-		s[l-1] = '\0';
+	while (fgets(input, MAX_LINE_LENGTH, stdin) != NULL) {
+		/* Remove final newline. */
+		input[strlen(input)-1] = '\0';
 
 		/* Duplicate string. */
-		if ((dups = strdup(s)) == NULL)
+		if ((dups = strdup(input)) == NULL)
 			exit(1);
 
 		/* Insert string. */

--- a/tests/kvlds-s3/Makefile
+++ b/tests/kvlds-s3/Makefile
@@ -76,3 +76,5 @@ CLEANFILES+=	lbs-s3.leak ktrace-lbs-s3.out kdump-lbs-s3.out
 CLEANFILES+=	s3.log
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/tests/kvlds/Makefile
+++ b/tests/kvlds/Makefile
@@ -75,3 +75,5 @@ CLEANFILES+=	kvlds.leak ktrace-kvlds.out kdump-kvlds.out
 CLEANFILES+=	test_kvlds.leak ktrace-test_kvlds.out kdump-test_kvlds.out
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/tests/kvlds/main.c
+++ b/tests/kvlds/main.c
@@ -396,9 +396,10 @@ err0:
 static int
 mutate(struct wire_requestqueue * Q)
 {
-	struct kvldskey * key = kvldskey_create("key", 3);
-	struct kvldskey * value = kvldskey_create("value", 5);
-	struct kvldskey * value2 = kvldskey_create("value2", 100);
+	struct kvldskey * key = kvldskey_create((const uint8_t *)"key", 3);
+	struct kvldskey * value = kvldskey_create((const uint8_t *)"value", 5);
+	struct kvldskey * value2 = kvldskey_create((const uint8_t *)"value2",
+	    100);
 
 	/*
 	 * Test B+Tree mutation code paths, one by one:
@@ -501,7 +502,7 @@ createmany(struct wire_requestqueue * Q, size_t N)
 	values = malloc(N * sizeof(struct kvldskey *));
 	for (i = 0; i < N; i++) {
 		sprintf(valbuf, "%zu", i);
-		values[i] = kvldskey_create(valbuf, strlen(valbuf));
+		values[i] = kvldskey_create((uint8_t *)valbuf, strlen(valbuf));
 	}
 
 	/* Store N key-value pairs. */

--- a/tests/lbs/Makefile
+++ b/tests/lbs/Makefile
@@ -68,3 +68,5 @@ test:	all
 CLEANFILES+=	lbs.leak test_lbs.leak
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/tests/mux/Makefile
+++ b/tests/mux/Makefile
@@ -73,3 +73,5 @@ test:	all
 CLEANFILES+=	mux.leak
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/tests/mux/main.c
+++ b/tests/mux/main.c
@@ -208,11 +208,11 @@ pingpong(struct wire_requestqueue * Q, const char * key, const char * to,
 	int i;
 
 	/* Create key and values. */
-	if ((k = kvldskey_create(key, strlen(key))) == NULL)
+	if ((k = kvldskey_create((const uint8_t *)key, strlen(key))) == NULL)
 		return (-1);
-	if ((v0 = kvldskey_create(from, strlen(from))) == NULL)
+	if ((v0 = kvldskey_create((const uint8_t *)from, strlen(from))) == NULL)
 		return (-1);
-	if ((v1 = kvldskey_create(to, strlen(to))) == NULL)
+	if ((v1 = kvldskey_create((const uint8_t *)to, strlen(to))) == NULL)
 		return (-1);
 
 	/* Write initial value if we're starting the pingpong. */
@@ -266,7 +266,7 @@ createmany(struct wire_requestqueue * Q, size_t N, char * prefix)
 	values = malloc(N * sizeof(struct kvldskey *));
 	for (i = 0; i < N; i++) {
 		sprintf(valbuf, "%zu", i);
-		values[i] = kvldskey_create(valbuf, strlen(valbuf));
+		values[i] = kvldskey_create((uint8_t *)valbuf, strlen(valbuf));
 	}
 
 	/* Store N key-value pairs. */

--- a/tests/s3/Makefile
+++ b/tests/s3/Makefile
@@ -71,3 +71,5 @@ CLEANFILES+=	test_s3.leak ktrace-test_s3.out kdump-test_s3.out
 CLEANFILES+=	s3.log
 
 .include <bsd.prog.mk>
+
+CFLAGS	+=	-Wno-unused-function

--- a/tests/s3/main.c
+++ b/tests/s3/main.c
@@ -146,8 +146,8 @@ putfile(struct wire_requestqueue * Q, const char * bucket)
 
 	/* PUT the object. */
 	opdone = 0;
-	if (proto_s3_request_put(Q, bucket, "s3-testfile", 11, "hello world",
-	    callback_put, NULL) ||
+	if (proto_s3_request_put(Q, bucket, "s3-testfile", 11,
+	    (const uint8_t *)"hello world", callback_put, NULL) ||
 	    events_spin(&opdone)) {
 		warn0("PUT failed");
 		exit(1);


### PR DESCRIPTION
This does not complete the compile fixes for Ubuntu; there still exists the non-C99-compliant `fcloseall()` in `tests/s3/main.c`.  However, I don't want to replace that with `fclose()` until I can be certain that I've cleaned up whatever memory leaks it was added to fix, but getting the test framework up and running will require more work (such as setting up AWS).