### PR TITLE
tests: increase delay for deleting old blocks

### DIFF
--- a/tests/kvlds/test_kvlds.sh
+++ b/tests/kvlds/test_kvlds.sh
@@ -74,7 +74,8 @@ fi
 
 # Make sure garbage got collected
 echo -n "Verifying that old blocks got deleted..."
-sleep 1
+# 1 second is not enough to reliably delete all old blocks
+sleep 10
 if [ `ls $STOR/blks_* | wc -l` = 1 ]; then
 	echo " PASSED!"
 else


### PR DESCRIPTION
Using `sleep 1` seemed to work 50% of the time on Ubuntu 14.04 (with an Intel
Core i5M).  `sleep 2` seems more reliable.