### PR TITLE
Add cleanup in non-FreeBSD "can't check memory leaks"

### DIFF
--- a/tests/mux/test_mux.sh
+++ b/tests/mux/test_mux.sh
@@ -118,6 +118,16 @@ rm $SOCKM $SOCKM.pid
 # check for memory leaks
 if ! [ `uname` = "FreeBSD" ]; then
 	echo "Can't check for memory leaks on `uname`"
+
+	# Kill the upstream server
+	kill `cat $SOCKK.pid`
+	rm $SOCKK $SOCKK.pid
+	kill `cat $SOCKL.pid`
+	rm $SOCKL $SOCKL.pid
+
+	# Clean up storage directory
+	rm -rf $STOR
+
 	exit 0
 fi
 


### PR DESCRIPTION
This arose because I couldn't unmount my encrypted loopback partition after finishing Tarsnap work, because the `lds` and `kvlds` daemons were still running.