### PR TITLE
Portability: replace "echo -n" with "printf"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ test:	all
 .for D in ${PROGS} ${BENCHES}
 ${PKG}-${VERSION}/${D}/Makefile:
 	echo '.POSIX:' > $@
-	( cd ${D} && echo -n 'PROG=kivaloo-' && ${MAKE} -V PROG ) >> $@
-	( cd ${D} && echo -n 'SRCS=' && ${MAKE} -V SRCS ) >> $@
-	( cd ${D} && echo -n 'IDIRS=' && ${MAKE} -V IDIRS ) >> $@
-	( cd ${D} && echo -n 'LDADD_REQ=' && ${MAKE} -V LDADD_REQ ) >> $@
+	( cd ${D} && printf 'PROG=kivaloo-' && ${MAKE} -V PROG ) >> $@
+	( cd ${D} && printf 'SRCS=' && ${MAKE} -V SRCS ) >> $@
+	( cd ${D} && printf 'IDIRS=' && ${MAKE} -V IDIRS ) >> $@
+	( cd ${D} && printf 'LDADD_REQ=' && ${MAKE} -V LDADD_REQ ) >> $@
 	cat Makefile.prog >> $@
 	( cd ${D} && ${MAKE} -V SRCS |	\
 	    tr ' ' '\n' |		\

--- a/tests/kvlds-s3/test_kvlds.sh
+++ b/tests/kvlds-s3/test_kvlds.sh
@@ -34,7 +34,7 @@ $LBS -s $SOCKL -t $SOCKS3 -b 512 -B $BUCKET
 $KVLDS -s $SOCKK -l $SOCKL -v 104 -C 1024
 
 # Test basic operations
-echo -n "Testing KVLDS operations against LBS-S3... "
+printf "Testing KVLDS operations against LBS-S3... "
 if $TESTKVLDS $SOCKK; then
 	echo " PASSED!"
 else
@@ -43,7 +43,7 @@ else
 fi
 
 # Test shutting down and restarting KVLDS
-echo -n "Testing disconnect and reconnect to LBS-S3... "
+printf "Testing disconnect and reconnect to LBS-S3... "
 kill `cat $SOCKK.pid`
 rm $SOCKK.pid $SOCKK
 $KVLDS -s $SOCKK -l $SOCKL -v 104 -C 1024
@@ -57,7 +57,7 @@ kill `cat $SOCKK.pid`
 rm $SOCKK.pid $SOCKK
 
 # Check that killing KVLDS can't break it
-echo -n "Testing LBS-S3 tolerance of KVLDS crashes..."
+printf "Testing LBS-S3 tolerance of KVLDS crashes..."
 $KVLDS -s $SOCKK -l $SOCKL -v 104
 $TESTKVLDS $SOCKK 2>/dev/null &
 sleep 0.1 && kill `cat $SOCKK.pid`
@@ -95,7 +95,7 @@ if ! [ `uname` = "FreeBSD" ]; then
 fi
 
 # Make sure LBS-S3 doesn't leak memory
-echo -n "Checking for memory leaks in LBS-S3..."
+printf "Checking for memory leaks in LBS-S3..."
 mkdir $TMPDIR
 $S3 -s $SOCKS3 -r $REGION -k $AWSKEY -l $LOGFILE -1
 ktrace -i -f ktrace-lbs-s3.out env MALLOC_CONF="junk:true,utrace:true"		\

--- a/tests/kvlds/test_kvlds.sh
+++ b/tests/kvlds/test_kvlds.sh
@@ -17,7 +17,7 @@ mkdir $STOR
 $LBS -s $SOCKL -d $STOR -b 512 -l 1000000
 
 # 96-byte keys are too big for 512-byte blocks
-echo -n "Testing keys too large for the block size... "
+printf "Testing keys too large for the block size... "
 if ! $KVLDS -s $SOCKK -l $SOCKL -k 96 -v 32 2>/dev/null; then
 	echo " PASSED!"
 else
@@ -27,7 +27,7 @@ fi
 rm $SOCKK
 
 # 200-byte values are too big for 512-byte blocks
-echo -n "Testing values too large for the block size... "
+printf "Testing values too large for the block size... "
 if ! $KVLDS -s $SOCKK -l $SOCKL -v 200 2>/dev/null; then
 	echo " PASSED!"
 else
@@ -37,7 +37,7 @@ fi
 rm $SOCKK
 
 # Try big requests to a server with a low maximum value length
-echo -n "Testing requests with values too large... "
+printf "Testing requests with values too large... "
 $KVLDS -s $SOCKK -l $SOCKL -v 50
 if ! $TESTKVLDS $SOCKK 2>/dev/null; then
 	echo " PASSED!"
@@ -49,7 +49,7 @@ kill `cat $SOCKK.pid`
 rm $SOCKK
 
 # Try big requests to a server with a low maximum key length
-echo -n "Testing requests with keys too large... "
+printf "Testing requests with keys too large... "
 $KVLDS -s $SOCKK -l $SOCKL -k 5
 if ! $TESTKVLDS $SOCKK 2>/dev/null; then
 	echo " PASSED!"
@@ -64,7 +64,7 @@ rm $SOCKK
 $KVLDS -s $SOCKK -l $SOCKL -v 104 -C 1024
 
 # Test basic operations
-echo -n "Testing KVLDS operations... "
+printf "Testing KVLDS operations... "
 if $TESTKVLDS $SOCKK; then
 	echo " PASSED!"
 else
@@ -73,7 +73,7 @@ else
 fi
 
 # Make sure garbage got collected
-echo -n "Verifying that old blocks got deleted..."
+printf "Verifying that old blocks got deleted..."
 # 1 second is not enough to reliably delete all old blocks
 sleep 10
 if [ `ls $STOR/blks_* | wc -l` = 1 ]; then
@@ -84,7 +84,7 @@ else
 fi
 
 # Make sure a second test works
-echo -n "Testing KVLDS connection-closing cleanup..."
+printf "Testing KVLDS connection-closing cleanup..."
 if ! $TESTKVLDS $SOCKK; then
 	echo " FAILED!"
 	exit 1
@@ -97,7 +97,7 @@ else
 fi
 
 # Check that an unclean disconnect is handled appropriately
-echo -n "Testing KVLDS disconnection cleanup..."
+printf "Testing KVLDS disconnection cleanup..."
 ( $TESTKVLDS $SOCKK & ) 2>/dev/null
 sleep 0.1 && killall test_kvlds
 ( $TESTKVLDS $SOCKK & ) 2>/dev/null
@@ -114,7 +114,7 @@ kill `cat $SOCKK.pid`
 rm $SOCKK.pid $SOCKK
 
 # Check that killing KVLDS can't break it
-echo -n "Testing KVLDS crash-safety..."
+printf "Testing KVLDS crash-safety..."
 $KVLDS -s $SOCKK -l $SOCKL -v 104
 $TESTKVLDS $SOCKK 2>/dev/null &
 sleep 0.1 && kill `cat $SOCKK.pid`
@@ -150,7 +150,7 @@ if ! [ `uname` = "FreeBSD" ]; then
 fi
 
 # Make sure we don't leak memory
-echo -n "Checking for memory leaks in KVLDS..."
+printf "Checking for memory leaks in KVLDS..."
 mkdir $STOR
 [ `uname` = "FreeBSD" ] && chflags nodump $STOR
 $LBS -s $SOCKL -d $STOR -b 512 -l 1000000 -1
@@ -178,7 +178,7 @@ fi
 rm leak.tmp
 
 # Process ktrace-test_kvlds output
-echo -n "Checking for memory leaks in KVLDS client code..."
+printf "Checking for memory leaks in KVLDS client code..."
 kdump -Ts -f ktrace-test_kvlds.out |		\
     grep ' test_kvlds ' > kdump-test_kvlds.out
 sh ../tools/memleak/memleak.sh kdump-test_kvlds.out test_kvlds.leak 2>leak.tmp

--- a/tests/lbs/test_lbs.sh
+++ b/tests/lbs/test_lbs.sh
@@ -15,7 +15,7 @@ mkdir $STOR
 $LBS -s $SOCK -d $STOR -b 512 -l 1000000
 
 # Perform a first test
-echo -n "Testing LBS operations..."
+printf "Testing LBS operations..."
 if $TESTLBS $SOCK; then
 	echo " PASSED!"
 else
@@ -24,7 +24,7 @@ else
 fi
 
 # Perform a second run
-echo -n "Testing LBS connection-closing cleanup..."
+printf "Testing LBS connection-closing cleanup..."
 if ! $TESTLBS $SOCK; then
 	echo " FAILED!"
 	exit 1
@@ -37,7 +37,7 @@ else
 fi
 
 # Check that an unclean disconnect is handled appropriately
-echo -n "Testing LBS disconnection cleanup..."
+printf "Testing LBS disconnection cleanup..."
 ( $TESTLBS $SOCK & ) 2>/dev/null
 sleep 0.1 && killall test_lbs
 if $TESTLBS $SOCK; then
@@ -48,7 +48,7 @@ else
 fi
 
 # Check that connections queue appropriately
-echo -n "Testing LBS connection queuing..."
+printf "Testing LBS connection queuing..."
 $TESTLBS $SOCK &
 sleep 0.1
 $TESTLBS $SOCK &
@@ -68,7 +68,7 @@ rm -rf $STOR
 
 # Test connecting via different addresses
 for S in "localhost:1234" "[127.0.0.1]:1235" "[::1]:1236"; do
-	echo -n "Testing LBS with socket at $S..."
+	printf "Testing LBS with socket at $S..."
 	if [ "$TRAVIS$S" = "true[::1]:1236" ]; then
 		echo " can't test IPv6 in Travis-CI."
 		break;
@@ -95,7 +95,7 @@ if ! [ `uname` = "FreeBSD" ]; then
 fi
 
 # Make sure we don't leak memory
-echo -n "Checking for memory leaks in LBS..."
+printf "Checking for memory leaks in LBS..."
 mkdir $STOR
 [ `uname` = "FreeBSD" ] && chflags nodump $STOR
 ktrace -i -f ktrace-lbs.out env MALLOC_CONF="junk:true,utrace:true"	\
@@ -121,7 +121,7 @@ fi
 rm leak.tmp
 
 # Process ktrace-test_lbs output
-echo -n "Checking for memory leaks in LBS client code..."
+printf "Checking for memory leaks in LBS client code..."
 kdump -Ts -f ktrace-test_lbs.out |		\
     grep ' test_lbs ' > kdump-test_lbs.out
 sh ../tools/memleak/memleak.sh kdump-test_lbs.out test_lbs.leak 2>leak.tmp

--- a/tests/mux/test_mux.sh
+++ b/tests/mux/test_mux.sh
@@ -22,7 +22,7 @@ $KVLDS -s $SOCKK -l $SOCKL -C 1024
 $MUX -t $SOCKK -s $SOCKM
 
 # Verify that we can run requests through MUX.
-echo -n "Testing KVLDS via MUX... "
+printf "Testing KVLDS via MUX... "
 if $TESTMUX $SOCKM 0.; then
 	echo " PASSED!"
 else
@@ -32,7 +32,7 @@ fi
 
 # Verify running several clients at once.
 #	( while ! [ -f .failed ]; do $TESTMUX $SOCKM ${X}. || touch .failed; done ) &
-echo -n "Testing multiple clients... "
+printf "Testing multiple clients... "
 for X in 1 2 3 4 5 6 7 8 9 10; do
 	( $TESTMUX $SOCKM ${X}. || touch .failed; ) &
 done
@@ -48,7 +48,7 @@ else
 fi
 
 # Verify that we can ping-pong via KVLDS.
-echo -n "Testing ping-pong... "
+printf "Testing ping-pong... "
 ( $TESTMUX $SOCKM ping || touch .failed ) &
 ( $TESTMUX $SOCKM pong || touch .failed ) &
 sleep 2
@@ -63,7 +63,7 @@ else
 fi
 
 # Verify that we survive the client dying
-echo -n "Testing client disconnection cleanup... "
+printf "Testing client disconnection cleanup... "
 ( $TESTMUX $SOCKM loop &) 2>/dev/null
 sleep 1 && killall test_mux
 if $TESTMUX $SOCKM 0.; then
@@ -74,7 +74,7 @@ else
 fi
 
 # Verify that we die if the upstream server dies
-echo -n "Testing server disconnection death... "
+printf "Testing server disconnection death... "
 ( $TESTMUX $SOCKM loop &) 2>/dev/null
 sleep 1 && kill `cat $SOCKK.pid`
 rm $SOCKK $SOCKK.pid
@@ -90,7 +90,7 @@ rm $SOCKM $SOCKM.pid
 $KVLDS -s $SOCKK -l $SOCKL -C 1024
 
 # Check that connection limit is enforced
-echo -n "Verifying that connection limit is enforced... "
+printf "Verifying that connection limit is enforced... "
 $MUX -t $SOCKK -s $SOCKM -n 1
 ( $TESTMUX $SOCKM ping & ) 2>/dev/null
 ( $TESTMUX $SOCKM pong & ) 2>/dev/null
@@ -104,7 +104,7 @@ fi
 killall test_mux
 
 # Check that the connection limit doesn't block connections permanently.
-echo -n "Verifying that connection acceptance is resumed... "
+printf "Verifying that connection acceptance is resumed... "
 if $TESTMUX $SOCKM 0.; then
 	echo " PASSED!"
 else
@@ -132,7 +132,7 @@ if ! [ `uname` = "FreeBSD" ]; then
 fi
 
 # Check for memory leaks
-echo -n "Checking for memory leaks... "
+printf "Checking for memory leaks... "
 ktrace -i -f ktrace-mux.out env MALLOC_CONF="junk:true,utrace:true"		\
 	$MUX -t $SOCKK -s $SOCKM
 for X in 1 2; do

--- a/tests/s3/test_s3.sh
+++ b/tests/s3/test_s3.sh
@@ -24,7 +24,7 @@ mkdir $TMPDIR
 $S3 -s $SOCKS3 -r $REGION -k $AWSKEY -l $LOGFILE
 
 # Run tests
-echo -n "test_s3... "
+printf "test_s3... "
 $TESTS3 $SOCKS3 $BUCKET > test_s3.log
 if cmp -s test_s3.log test_s3.good; then
 	rm test_s3.log
@@ -45,7 +45,7 @@ if ! [ `uname` = "FreeBSD" ]; then
 fi
 
 # Make sure we don't leak memory
-echo -n "Checking for memory leaks in S3 daemon..."
+printf "Checking for memory leaks in S3 daemon..."
 ktrace -i -f ktrace-s3.out env MALLOC_CONF="junk:true,utrace:true"	\
     $S3 -s $SOCKS3 -r $REGION -k $AWSKEY -l $LOGFILE -1
 ktrace -i -f ktrace-test_s3.out env MALLOC_CONF="junk:true,utrace:true"	\
@@ -68,7 +68,7 @@ fi
 rm leak.tmp
 
 # Process ktrace-test_s3 output
-echo -n "Checking for memory leaks in s3 client code..."
+printf "Checking for memory leaks in s3 client code..."
 kdump -Ts -f ktrace-test_s3.out |		\
     grep ' test_s3 ' > kdump-test_s3.out
 sh ../tools/memleak/memleak.sh kdump-test_s3.out test_s3.leak 2>leak.tmp


### PR DESCRIPTION
"echo -n" is not portable; we should use printf instead.

    It is not possible to use echo portably across all POSIX systems unless
    both -n (as the first argument) and escape sequences are omitted.

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html