### PR TITLE
build: remove NO_MAN, replace with MAN1= (null)

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -6,7 +6,6 @@ cflags-${X:.c=.o}:
 .endfor
 
 # Defaults for all kivaloo code
-NO_MAN	?=	yes
 WARNS	?=	3
 
 # Use POSIX standard

--- a/tests/kvlds-s3/Makefile.BSD
+++ b/tests/kvlds-s3/Makefile.BSD
@@ -1,6 +1,7 @@
 PROG=	test_kvlds
 .PATH.c	:	../kvlds
 SRCS=	main.c
+MAN1=
 
 # Data structures (libcperciva)
 .PATH.c	:	../../libcperciva/datastruct

--- a/tests/kvlds/Makefile.BSD
+++ b/tests/kvlds/Makefile.BSD
@@ -1,5 +1,6 @@
 PROG=	test_kvlds
 SRCS=	main.c
+MAN1=
 
 # Data structures (libcperciva)
 .PATH.c	:	../../libcperciva/datastruct

--- a/tests/lbs/Makefile.BSD
+++ b/tests/lbs/Makefile.BSD
@@ -1,5 +1,6 @@
 PROG=	test_lbs
 SRCS=	main.c
+MAN1=
 
 # Data structures
 .PATH.c	:	../../libcperciva/datastruct

--- a/tests/mux/Makefile.BSD
+++ b/tests/mux/Makefile.BSD
@@ -1,5 +1,6 @@
 PROG=	test_mux
 SRCS=	main.c
+MAN1=
 
 # Data structures (libcperciva)
 .PATH.c	:	../../libcperciva/datastruct

--- a/tests/s3/Makefile.BSD
+++ b/tests/s3/Makefile.BSD
@@ -1,5 +1,6 @@
 PROG=	test_s3
 SRCS=	main.c
+MAN1=
 
 # Data structures
 .PATH.c	:	../../libcperciva/datastruct


### PR DESCRIPTION
It appears that NO_MAN is now obsolete.  It doesn't appear in /usr/share/mk/*.mk, and I found a reference to removing it from the FreeBSD tree:
https://lists.freebsd.org/pipermail/svn-src-head/2014-April/057960.html

I added explicit

    MAN1=

lines to all Makefile.BSD so that "make test" functions on FreeBSD 11. (interestingly, NetBSD's "bmake" on Ubuntu had no problems before this commit, which is why my testing and Travis-CI didn't complain)