### PR TITLE
build: fix POSIX compatibility detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ TESTS=	tests/lbs tests/kvlds tests/mux tests/s3 tests/kvlds-s3 \
 	${BENCHES}
 BINDIR_DEFAULT=	/usr/local/bin
 CFLAGS_DEFAULT=	-O2
+LIBCPERCIVA_DIR=	libcperciva
 TEST_CMD=	${MAKE} -C tests test
 
 ### Shared code between Tarsnap projects.


### PR DESCRIPTION
I accidentally this in 937b1b2ea057817ff331c974d73faa6d4ba35593 because
${LIBCPERCIVA_DIR} wasn't defined.