### PR TITLE
Correctly assert lengths read by serverpool

### DIFF
--- a/lib/serverpool/serverpool.c
+++ b/lib/serverpool/serverpool.c
@@ -153,7 +153,7 @@ callback_read_len(void * cookie, ssize_t readlen)
 
 	/* We should get -1 (error), 0 (EOF), or a size_t. */
 	assert((readlen == -1) || (readlen == 0) ||
-	    (readlen = sizeof(size_t)));
+	    (readlen == sizeof(size_t)));
 
 	/* Handle failures. */
 	if (readlen == -1)
@@ -212,8 +212,8 @@ callback_read_addr(void * cookie, ssize_t readlen)
 	struct serverpool * P = cookie;
 	struct sock_addr * sa = NULL;
 
-	/* We should get -1 (error), 0 (EOF), or a size_t. */
-	assert((readlen == -1) || (readlen == 0) || (readlen = P->addrlen));
+	/* We should get -1 (error), 0 (EOF), or a complete address. */
+	assert((readlen == -1) || (readlen == 0) || (readlen == P->addrlen));
 
 	/* Handle failures. */
 	if (readlen == -1)


### PR DESCRIPTION
This was a = / == typo; we want to assert that readlen is correct,
not set it to the right length.

Fortunately this was mostly harmless: It happens when asserting
the length we're reading over a socket from ourselves, and readlen
would only have its value changed if the assertion was about to
fail.

Reported by:	Coverity Scan