### PR TITLE
Wait the right duration for deletes to complete

### DIFF
--- a/tests/kvlds-ddbkv/test_kvlds.sh
+++ b/tests/kvlds-ddbkv/test_kvlds.sh
@@ -43,7 +43,9 @@ else
 fi
 
 # Let kvlds delete old pages before we shut down
-sleep 1800
+while find ${LOGFILE} -mtime -5s | grep -q .; do
+	sleep 1
+done
 
 # Shut down kvlds; other daemons should shut down automatically
 kill `cat $SOCKK.pid`


### PR DESCRIPTION
Rather than using a hard-coded 1800 second sleep to wait for pages
to be deleted after a test completes, watch the log file and stop
when we go for five seconds without anything happening.