### PR TITLE
kvlds: Don't automatically disable cleaning

### DIFF
--- a/kvlds/btree.c
+++ b/kvlds/btree.c
@@ -187,17 +187,6 @@ btree_init(struct wire_requestqueue * Q_lbs, uint64_t npages,
 		goto err1;
 	}
 
-	/*
-	 * If there's a gap between last-block-written and next-writable-block
-	 * then we're using a sparse block space; our cleaning code can't
-	 * handle this, since it estimates the number of "garbage" pages by
-	 * comparing the largest and smallest block #s against the number of
-	 * nodes, i.e., it implicitly assumes a dense block space.  Set the
-	 * storage cost to zero in this case (which disables cleaning).
-	 */
-	if (PC.lastblk + 1 != T->nextblk)
-		Scost = 0.0;
-
 	/* If we have neither npages nor npagebytes, set a default. */
 	if ((npages == (uint64_t)(-1)) && (npagebytes == (uint64_t)(-1))) {
 #if 128 * 1024 * 1024 < SIZE_MAX


### PR DESCRIPTION
Prior to this commit, if lastblk != nextblk - 1, we assumed that the
block ID space was sparse and disabled cleaning since our normal
process for cleaning would not work.  This was necessary when using
lbs-s3 as a page storage backend.

We now have lbs-dynamodb, which if an APPEND is interrupted, can have
lastblk pointing at the last page of the last *completed* APPEND while
nextblk points after the *interrupted* APPEND; this is perfectly
harmless and does not indicate a sparsity to block IDs.

Users of kvlds with lbs-s3 should manually disable cleaning.