### PR TITLE
Lbs dynamodb concurrency subset fix

### DIFF
--- a/lbs-dynamodb/deleteto.c
+++ b/lbs-dynamodb/deleteto.c
@@ -10,18 +10,32 @@
 
 #include "deleteto.h"
 
+/* Maximum number of deletes in progress at once. */
+#define MAXINPROGRESS	64
+
+/* Maximum number of deletes to replay if we crash. */
+#define MAXUNRECORDED	8000
+
+struct delete {
+	struct deleteto * D;
+	uint64_t N;
+	struct delete * prev;
+	struct delete * next;
+};
+
 struct deleteto {
 	struct wire_requestqueue * Q;
 	struct metadata * MD;
 	uint64_t N;		/* Delete objects below this number. */
 	uint64_t M;		/* We've issued deletes up to this number. */
-	size_t npending;	/* Operations in progress. */
-	int updateDeletedTo;	/* M has changed since it was last stored. */
+	size_t npending;	/* DELETE operations in progress. */
 	int shuttingdown;	/* Stop issuing DELETEs. */
 	int shutdown;		/* Everything is done. */
+	struct delete * ip_head;	/* Head of deletes in progress list. */
+	struct delete * ip_tail;	/* Tail of deletes in progress list. */
 };
 
-static int callback_poke(void *);
+static int poke(void *);
 static int callback_done(void *, int);
 
 /**
@@ -41,15 +55,16 @@ deleteto_init(struct wire_requestqueue * Q_DDBKV, struct metadata * M)
 	D->MD = M;
 	D->N = 0;
 	D->npending = 0;
-	D->updateDeletedTo = 0;
 	D->shuttingdown = 0;
 	D->shutdown = 0;
+	D->ip_head = NULL;
+	D->ip_tail = NULL;
 
-	/* Read "DeletedTo" into M. */
+	/* How far are we guaranteed was previously deleted? */
 	D->M = metadata_deletedto_read(D->MD);
 
 	/* We want to be poked every time a metadata write completes. */
-	metadata_deletedto_register(D->MD, callback_poke, D);
+	metadata_deletedto_register(D->MD, poke, D);
 
 	/* Success! */
 	return (D);
@@ -61,46 +76,59 @@ err0:
 
 /* Do a round of deletes if appropriate. */
 static int
-poke(struct deleteto * D)
+poke(void * cookie)
 {
+	struct deleteto * D = cookie;
+	struct delete * D1;
+	uint64_t deletedto;
 
-	/* If we're already busy, don't do anything. */
-	if (D->npending)
-		return (0);
-
-	/*
-	 * Store DeletedTo if we want to; since we have no requests in
-	 * progress, we're guaranteed to have deleted everything below M.
-	 */
-	if (D->updateDeletedTo) {
-		if (metadata_deletedto_write(D->MD, D->M))
-			goto err0;
-		D->updateDeletedTo = 0;
-		return (0);
-	}
+	/* Tell the metadata code how far we've finished deleting. */
+	if (D->ip_head != NULL)
+		deletedto = D->ip_head->N;
+	else
+		deletedto = D->M;
+	if (metadata_deletedto_write(D->MD, deletedto))
+		goto err0;
 
 	/* Are we waiting to shut down? */
 	if (D->shuttingdown) {
-		D->shutdown = 1;
+		/*
+		 * If there's no deletes in progress and the metadata is up to
+		 * date with how far we've deleted, we're done.
+		 */
+		if ((D->npending == 0) &&
+		    (metadata_deletedto_read(D->MD) == deletedto))
+			D->shutdown = 1;
+
+		/* Either way, return without sending any more. */
 		return (0);
 	}
 
 	/* Can we issue more deletes? */
-	while (D->M < D->N) {
-		/* Issue a delete for M. */
+	while ((D->M < D->N) &&
+	    (D->npending < MAXINPROGRESS) &&
+	    (D->M < metadata_deletedto_read(D->MD) + MAXUNRECORDED)) {
+		/* Bake a cookie for deleting M. */
+		if ((D1 = malloc(sizeof(struct delete))) == NULL)
+			goto err0;
+		D1->D = D;
+		D1->N = D->M;
+		D1->prev = D->ip_tail;
+		D1->next = NULL;
+		if (D->ip_head == NULL)
+			D->ip_head = D1;
+		else
+			D->ip_tail->next = D1;
+		D->ip_tail = D1;
+
+		/* Issue the delete. */
 		if (proto_dynamodb_kv_request_delete(D->Q, objmap(D->M),
-		    callback_done, D))
+		    callback_done, D1))
 			goto err0;
 		D->npending++;
 
 		/* We've issued deletes for everything under one more. */
 		D->M++;
-
-		/* If we've finished a "century", stop here for a moment. */
-		if ((D->M % 256) == 0) {
-			D->updateDeletedTo = 1;
-			break;
-		}
 	}
 
 	/* Success! */
@@ -111,20 +139,34 @@ err0:
 	return (-1);
 }
 
-/* One of the DynamoDB-KV operations kicked off by poke() has completed. */
+/* A delete has completed. */
 static int
 callback_done(void * cookie, int status)
 {
-	struct deleteto * D = cookie;
+	struct delete * D1 = cookie;
+	struct deleteto * D = D1->D;
 
 	/* Sanity-check. */
 	assert(D->npending > 0);
 
 	/* Failures are bad, m'kay? */
 	if (status) {
-		warn0("DynamoDB-KV operation failed!");
+		warn0("DynamoDB-KV DELETE operation failed!");
 		goto err0;
 	}
+
+	/* Remove from linked list of in-progress deletes. */
+	if (D1->prev != NULL)
+		D1->prev->next = D1->next;
+	else
+		D->ip_head = D1->next;
+	if (D1->next != NULL)
+		D1->next->prev = D1->prev;
+	else
+		D->ip_tail = D1->prev;
+
+	/* Free cookie. */
+	free(D1);
 
 	/* We've finished an operation. */
 	D->npending -= 1;
@@ -139,16 +181,6 @@ callback_done(void * cookie, int status)
 err0:
 	/* Failure! */
 	return (-1);
-}
-
-/* A metadata write has been performed. */
-static int
-callback_poke(void * cookie)
-{
-	struct deleteto * D = cookie;
-
-	/* Check what we should do next. */
-	return (poke(D));
 }
 
 /**
@@ -179,9 +211,6 @@ deleteto_stop(struct deleteto * D)
 
 	/* We don't want to do any more DELETEs, just shut down. */
 	D->shuttingdown = 1;
-
-	/* Store DeletedTo when all the DELETEs have finished. */
-	D->updateDeletedTo = 1;
 
 	/* Poke the deleter in case it's not already doing anything. */
 	if (poke(D))

--- a/lbs-dynamodb/deleteto.c
+++ b/lbs-dynamodb/deleteto.c
@@ -48,6 +48,9 @@ deleteto_init(struct wire_requestqueue * Q_DDBKV, struct metadata * M)
 	/* Read "DeletedTo" into M. */
 	D->M = metadata_deletedto_read(D->MD);
 
+	/* We want to be poked every time a metadata write completes. */
+	metadata_deletedto_register(D->MD, callback_poke, D);
+
 	/* Success! */
 	return (D);
 
@@ -70,9 +73,8 @@ poke(struct deleteto * D)
 	 * progress, we're guaranteed to have deleted everything below M.
 	 */
 	if (D->updateDeletedTo) {
-		if (metadata_deletedto_write(D->MD, D->M, callback_poke, D))
+		if (metadata_deletedto_write(D->MD, D->M))
 			goto err0;
-		D->npending++;
 		D->updateDeletedTo = 0;
 		return (0);
 	}
@@ -139,17 +141,11 @@ err0:
 	return (-1);
 }
 
-/* The deletedto metadata value has been updated. */
+/* A metadata write has been performed. */
 static int
 callback_poke(void * cookie)
 {
 	struct deleteto * D = cookie;
-
-	/* Sanity-check. */
-	assert(D->npending > 0);
-
-	/* We've finished an operation. */
-	D->npending -= 1;
 
 	/* Check what we should do next. */
 	return (poke(D));
@@ -194,6 +190,9 @@ deleteto_stop(struct deleteto * D)
 	/* Wait for all pending operations to finish. */
 	if (events_spin(&D->shutdown))
 		goto err0;
+
+	/* We don't want to know about metadata writes completing. */
+	metadata_deletedto_register(D->MD, NULL, NULL);
 
 	/* Free the DeleteTo structure. */
 	free(D);

--- a/lbs-dynamodb/metadata.h
+++ b/lbs-dynamodb/metadata.h
@@ -28,6 +28,19 @@ int metadata_nextblk_write(struct metadata *, uint64_t,
     int (*)(void *), void *);
 
 /**
+ * metadata_lastblk_read(M):
+ * Return the "lastblk" value.
+ */
+uint64_t metadata_lastblk_read(struct metadata *);
+
+/**
+ * metadata_lastblk_write(M, lastblk, callback, cookie):
+ * Store "lastblk" value.  Invoke ${callback}(${cookie}) on success.
+ */
+int metadata_lastblk_write(struct metadata *, uint64_t,
+    int (*)(void *), void *);
+
+/**
  * metadata_deletedto_read(M):
  * Return the "deletedto" value.
  */

--- a/lbs-dynamodb/metadata.h
+++ b/lbs-dynamodb/metadata.h
@@ -47,11 +47,19 @@ int metadata_lastblk_write(struct metadata *, uint64_t,
 uint64_t metadata_deletedto_read(struct metadata *);
 
 /**
- * metadata_deletedto_write(M, deletedto, callback, cookie):
- * Store "deletedto" value.  Invoke ${callback}(${cookie}) on success.
+ * metadata_deletedto_write(M, deletedto):
+ * Store "deletedto" value.
  */
-int metadata_deletedto_write(struct metadata *, uint64_t,
-    int (*)(void *), void *);
+int metadata_deletedto_write(struct metadata *, uint64_t);
+
+/**
+ * metadata_deletedto_register(M, callback, cookie):
+ * Register ${callback}(${cookie}) to be called every time metadata is stored.
+ * This API exists for the benefit of the deletedto code; only one callback can
+ * be registered in this manner at once, and the callback must be reset to NULL
+ * before metadata_free is called.
+ */
+void metadata_deletedto_register(struct metadata *, int(*)(void *), void *);
 
 /**
  * metadata_free(M):

--- a/lbs-dynamodb/metadata.h
+++ b/lbs-dynamodb/metadata.h
@@ -50,7 +50,7 @@ uint64_t metadata_deletedto_read(struct metadata *);
  * metadata_deletedto_write(M, deletedto):
  * Store "deletedto" value.
  */
-int metadata_deletedto_write(struct metadata *, uint64_t);
+void metadata_deletedto_write(struct metadata *, uint64_t);
 
 /**
  * metadata_deletedto_register(M, callback, cookie):
@@ -60,6 +60,12 @@ int metadata_deletedto_write(struct metadata *, uint64_t);
  * before metadata_free is called.
  */
 void metadata_deletedto_register(struct metadata *, int(*)(void *), void *);
+
+/**
+ * metadata_flush(M):
+ * Trigger a flush of pending metadata updates.
+ */
+int metadata_flush(struct metadata *);
 
 /**
  * metadata_free(M):


### PR DESCRIPTION
Revision of #230, moving the repurposing of `struct metadata.write_wanted` earlier and also fixing a bug.