### PR TITLE
Document Homebrew OpenSSL flags for macOS builds

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -1,10 +1,11 @@
 To build and install kivaloo, run:
 # make BINDIR=/path/to/target/directory install
 
-Kivaloo should build and run on any IEEE Std 1003.1 (POSIX) compliant system
-which includes the Software Development Utilities and Threads options.  If it
-doesn't, this is a bug -- please report it!
-
+Kivaloo should build and run on any IEEE Std 1003.1 (POSIX) compliant
+system which
+  1. Includes the Software Development Utilities option,
+  2. Has OpenSSL available via -lcrypto and #include <openssl/foo>, and
+  3. Provides /dev/urandom.
 
 Tests
 -----
@@ -54,6 +55,12 @@ kivaloo, that info should be saved in a text file with the form:
 
 Platform-specific notes
 -----------------------
+
+- On macOS, OpenSSL installed via Homebrew is not in the default compiler
+  search path.  If `make` fails with a missing OpenSSL header such as
+  `openssl/err.h`, build with the OpenSSL paths specified explicitly:
+      make CFLAGS="-O2 -I/opt/homebrew/opt/openssl@3/include" \
+          LDADD_EXTRA="-L/opt/homebrew/opt/openssl@3/lib"
 
 - The performance of SSL networking can be improved if SO_NOSIGPIPE is
   available in <sys/socket.h>.  To get this in FreeBSD, define __BSD_VISIBLE,


### PR DESCRIPTION
Summary:
- document OpenSSL as a build dependency alongside POSIX utilities and threads
- add the Homebrew OpenSSL include/library flags needed on macOS when headers are outside the default compiler path

Verification:
- On Apple Silicon macOS, plain make fails with openssl/err.h not found in libcperciva/network_ssl/network_ssl.c.
- make CFLAGS="-O2 -I/opt/homebrew/opt/openssl@3/include" LDADD_EXTRA="-L/opt/homebrew/opt/openssl@3/lib" completes successfully.

The project CI already uses the same Homebrew OpenSSL paths for macOS builds, so this keeps BUILDING in sync with the currently required local build invocation.

If this qualifies under the documented Tarsnap bug bounty, this is intended as a documentation clarity/build-instructions patch.