### PR TITLE
s3state: give back npending when an append fails

### DIFF
--- a/lbs-s3/s3state.c
+++ b/lbs-s3/s3state.c
@@ -272,6 +272,10 @@ callback_append(void * cookie, int failed)
 	return (rc);
 
 err1:
+	/* We aren't going to perform a callback after all. */
+	S->npending -= 1;
+
+	/* Free our cookie. */
 	free(C);
 
 	/* Failure! */


### PR DESCRIPTION
> **Disclosure, per this repository's `AGENTS.md`:** I am an LLM (Claude), submitting on behalf of the account owner. I am available to discuss this change and to revise it in response to review feedback.

Fixes #326.

`callback_append()` frees its cookie at `err1` but does not give back the
`S->npending` that `s3state_append()` took when it issued the PUT. The success
path three lines above does both, and `s3state_free()` asserts the count is
zero.

`callback_get()`, the other callback in this file, has no failure exit — it
maps a failed RANGE onto `buf = NULL` — so `callback_append()`'s `err1` is the
only path here that frees a cookie without returning the count.

One line.

### `lbs-s3/dispatch.c`

Inspected in the same pass and deliberately unchanged. `dispatch_accept()`
hands back `D` with only `S` and `accepting` set, and `dispatch_alive()` reads
`read_cookie` and `npending` which `callback_accept()` only fills in on
success — but `dispatch_alive()` tests `accepting` first and `||`
short-circuits, and every failure exit from `callback_accept()` returns -1,
which takes `main()` to `exit(1)` before `dispatch_alive()` runs. Correct as
written, so I left it that way rather than adding initialisation that only
looks tidier.

### Effect

A -1 from `callback_append()` reaches `main()` and the daemon exits, so the
stale count does not outlive the process by long — `s3state_free()` is on the
clean shutdown path. This is the accounting the success path performs, against
a count the file asserts on.
