### PR TITLE
Fix quantile interpolation overflow

### DIFF
--- a/lib/datastruct/onlinequantile.c
+++ b/lib/datastruct/onlinequantile.c
@@ -91,7 +91,13 @@ onlinequantile_get(struct onlinequantile * Q, double * x)
 		assert(Q->N_smaller < Q->N);
 
 		/* Compute the average. */
-		*x = Q->smaller_max + (Q->larger_min - Q->smaller_max) * r;
+		if ((Q->smaller_max < 0.0) && (Q->larger_min > 0.0)) {
+			/* Avoid overflow when subtracting opposite-signed values. */
+			*x = Q->smaller_max * (1.0 - r) + Q->larger_min * r;
+		} else {
+			*x = Q->smaller_max +
+			    (Q->larger_min - Q->smaller_max) * r;
+		}
 	} else {
 		/* The median is just a single value. */
 		*x = Q->smaller_max;

--- a/tests/onlinequantile/case6.txt
+++ b/tests/onlinequantile/case6.txt
@@ -1,0 +1,5 @@
+# Interpolation must not overflow for finite values of opposite signs.
+q	0.5
+a	-1e308
+a	1e308
+g	0

--- a/tests/onlinequantile/test_onlinequantile.sh
+++ b/tests/onlinequantile/test_onlinequantile.sh
@@ -7,3 +7,4 @@ set -e
 ./test_onlinequantile case3.txt
 ./test_onlinequantile case4.txt
 ./test_onlinequantile case5.txt
+./test_onlinequantile case6.txt


### PR DESCRIPTION
Fixes #367.

Use a weighted sum when the interpolation endpoints have opposite signs, avoiding overflow in their difference. The median of `[-1e308, 1e308]` now returns `0` instead of `+inf`. Adds a regression fixture to the existing test script.

Validation: the actual C implementation passes five quantile checks and all six fixtures through a standalone MSVC C11 harness. The original fails three of those quantile checks. The native POSIX runner and full suite were not run on this Windows host.